### PR TITLE
Adding continue to for loop to ignore sensors with wrong name

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,6 +107,7 @@ HiveMotionSensor.prototype = {
 					var sensorName = body.nodes[i].name;
 					if (sensorName !== this.name ) {
 						this.log("Ignoring " + sensorName);
+						continue;
 					}
 					var sensorMotionStarted = body.nodes[i].attributes.motionStarted.displayValue;
 					var sensorMotionEnded = body.nodes[i].attributes.motionEnded.displayValue;


### PR DESCRIPTION
Your current logic won't ignore sensors. You needed to add a `continue` after the log to make sure you don't store the details for the incorrect sensor. 
